### PR TITLE
Update PatientSetQueryBuilderService.groovy

### DIFF
--- a/grails-app/services/org/transmartproject/db/querytool/PatientSetQueryBuilderService.groovy
+++ b/grails-app/services/org/transmartproject/db/querytool/PatientSetQueryBuilderService.groovy
@@ -58,7 +58,7 @@ class PatientSetQueryBuilderService {
             [
                 id: panelNum++,
                 select: "SELECT patient_num " +
-                        "FROM observation_fact WHERE $bigPredicate",
+                        "FROM observation_fact WHERE $bigPredicate AND concept_cd != 'SECURITY'",
                 invert: panel.invert,
             ]
         }.sort { a, b ->


### PR DESCRIPTION
The facts containing the concept_cd 'SECURITY' should never be retreived (Patient set can contain patient from other nodes if not expluded). I do not know if this is the best place to put it, but I imagine you will have a better idea. Another aproach would be to have some sort of EXCLUDE constraint which, than, would allow us to move the constraint into the JS file for subset query.
