### PR TITLE
Replace RNAseq name to fix export (TMART-312)

### DIFF
--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogModule.groovy
@@ -42,7 +42,7 @@ import static org.hibernate.sql.JoinFragment.INNER_JOIN
  */
 class RnaSeqCogModule extends AbstractHighDimensionDataTypeModule {
 
-    final String name = 'rnaseq_cog'
+    final String name = 'rnaseqcog'
 
     final String description = "Messenger RNA data (Sequencing)"
 


### PR DESCRIPTION
Data type names containing an underscore make the export fail. This name has also to be replaced in Rmodules
