### PR TITLE
Overcome ora max number of expression in a list

### DIFF
--- a/grails-app/services/org/transmartproject/db/support/ChoppedInQueryCondition.groovy
+++ b/grails-app/services/org/transmartproject/db/support/ChoppedInQueryCondition.groovy
@@ -1,0 +1,64 @@
+package org.transmartproject.db.support
+
+import org.apache.commons.lang.StringEscapeUtils
+import grails.orm.HibernateCriteriaBuilder
+import org.transmartproject.core.exceptions.InvalidRequestException
+
+/**
+ * This class aimed to overcome oracle limitation on the number of items in IN clause:
+ * Message: ORA-01795: maximum number of expressions in a list is 1000
+ *
+ * This class constructs composite condition
+ * Instead of making one condition
+ * patient_num IN (1, 2, 3, ... 1200)
+ * it chops list of items and join sub-conditions with OR operations
+ * patient_num IN (1, 2, 3, ... 1000) OR patient_num IN (1001, 1002, 1003, ... 1200)
+ */
+class ChoppedInQueryCondition {
+
+    static final int MAX_LIST_SIZE = 1000
+    static final String ALWAYS_TRUE_CONDITION = '1=1'
+
+    private final String fieldName
+    private final List inItems
+
+    ChoppedInQueryCondition(String fieldName, List inItems) {
+        this.fieldName = fieldName
+        this.inItems = inItems
+    }
+
+    @Lazy Map parametersValues = {
+        if(!inItems) return [:]
+        def chunks = inItems.collate(MAX_LIST_SIZE)
+        (0..<chunks.size()).collectEntries { index -> ["_${index}".toString(), chunks[index]] }
+    }()
+
+    @Lazy String queryConditionTemplate = {
+        constructChoppedInQueryCondition { parVals -> ":${parVals.key}"}
+    }()
+
+    /**
+     * You should prefer using queryConditionTemplate instead.
+     */
+    @Lazy String populatedQueryCondition = {
+        constructChoppedInQueryCondition { parVals ->
+            //Note that single quotes always added. Disregard the fact whether value is number or string. AFAIK It's fine with SQL.
+            parVals.value.collect{"'${StringEscapeUtils.escapeSql(it.toString())}'"}.join(',')}
+    }()
+
+    void addConstraintsToCriteria(HibernateCriteriaBuilder builder) throws InvalidRequestException {
+        builder.with {
+            or {
+                parametersValues.collect { parVal ->
+                    'in' fieldName, parVal.value
+                }
+            }
+        }
+    }
+
+    private String constructChoppedInQueryCondition(Closure<String> constructValues) {
+        def subCondition = parametersValues.collect { parVal ->
+            "${fieldName} IN (${constructValues(parVal)})"}.join(' OR ')
+        "(${subCondition ?: ALWAYS_TRUE_CONDITION})".toString()
+    }
+}

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionDataTypeResourceImpl.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionDataTypeResourceImpl.groovy
@@ -36,6 +36,7 @@ import org.transmartproject.core.exceptions.UnsupportedByDataTypeException
 import org.transmartproject.db.dataquery.highdim.assayconstraints.MarkerTypeConstraint
 import org.transmartproject.db.dataquery.highdim.dataconstraints.CriteriaDataConstraint
 import org.transmartproject.db.dataquery.highdim.projections.CriteriaProjection
+import org.transmartproject.db.support.ChoppedInQueryCondition
 
 @Log4j
 class HighDimensionDataTypeResourceImpl implements HighDimensionDataTypeResource {
@@ -89,9 +90,8 @@ class HighDimensionDataTypeResourceImpl implements HighDimensionDataTypeResource
         HibernateCriteriaBuilder criteriaBuilder =
             module.prepareDataQuery(projection, openSession())
 
-        criteriaBuilder.with {
-            'in' 'assay.id', assays*.id
-        }
+        new ChoppedInQueryCondition('assay.id', assays*.id)
+            .addConstraintsToCriteria(criteriaBuilder)
 
         /* apply changes to criteria from projection, if any */
         if (projection instanceof CriteriaProjection) {

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/assayconstraints/AssayIdListConstraint.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/assayconstraints/AssayIdListConstraint.groovy
@@ -21,6 +21,7 @@ package org.transmartproject.db.dataquery.highdim.assayconstraints
 
 import grails.orm.HibernateCriteriaBuilder
 import org.transmartproject.core.exceptions.InvalidRequestException
+import org.transmartproject.db.support.ChoppedInQueryCondition
 
 class AssayIdListConstraint extends AbstractAssayConstraint {
 
@@ -29,8 +30,7 @@ class AssayIdListConstraint extends AbstractAssayConstraint {
     @Override
     void addConstraintsToCriteria(HibernateCriteriaBuilder builder) throws InvalidRequestException {
         /** @see org.transmartproject.db.dataquery.highdim.DeSubjectSampleMapping */
-        builder.with {
-            'in' 'id', ids
-        }
+        new ChoppedInQueryCondition('id', ids)
+            .addConstraintsToCriteria(builder)
     }
 }

--- a/transmart-core-db-tests/test/unit/org/transmartproject/db/support/ChoppedInQueryConditionTest.groovy
+++ b/transmart-core-db-tests/test/unit/org/transmartproject/db/support/ChoppedInQueryConditionTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2013-2014 The Hyve B.V.
+ *
+ * This file is part of transmart-core-db.
+ *
+ * Transmart-core-db is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * transmart-core-db.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.transmartproject.db.support
+
+import org.junit.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+
+class ChoppedInQueryConditionTest {
+
+    @Test
+    void testNumOfItemsLessThenMax() {
+        def condition = new ChoppedInQueryCondition('patient_num', [1, 2, 3])
+        assertThat condition.parametersValues, hasEntry(is('_0'), contains(1, 2, 3))
+        assertThat condition.queryConditionTemplate, equalTo("(patient_num IN (:_0))")
+    }
+
+    @Test
+    void testNumOfItemsMoreThenMax() {
+        def condition = new ChoppedInQueryCondition('patient_num', (1..2500).toList())
+        assertThat condition.parametersValues, allOf(
+                hasEntry(is('_0'), hasSize(1000)),
+                hasEntry(is('_1'), hasSize(1000)),
+                hasEntry(is('_2'), hasSize(500)),
+        )
+        assertThat condition.queryConditionTemplate, equalTo("(patient_num IN (:_0) OR patient_num IN (:_1) OR patient_num IN (:_2))")
+        assertThat condition.populatedQueryCondition, allOf(
+                startsWith("(patient_num IN ('1','2','3',"),
+                containsString("'1000') OR patient_num IN ('1001','1002','1003',"),
+                containsString("'2000') OR patient_num IN ('2001','2002','2003',"), endsWith(",'2498','2499','2500'))")
+        )
+    }
+
+    @Test
+    void tesEmptyIds() {
+        def condition = new ChoppedInQueryCondition('patient_num', [])
+        assertThat condition.parametersValues, equalTo([:])
+        assertThat condition.queryConditionTemplate, equalTo("(1=1)")
+    }
+
+}


### PR DESCRIPTION
This class aimed to overcome oracle limitation on the number of items in IN clause:
Message: ORA-01795: maximum number of expressions in a list is 1000

This class constructs composite condition
Instead of making one condition
patient_num IN (1, 2, 3, ... 1200)
it chops list of items and join sub-conditions with OR operations
patient_num IN (1, 2, 3, ... 1000) OR patient_num IN (1001, 1002, 1003, ... 1200)
