### PR TITLE
Data Export: Fix VCF calculations.

### DIFF
--- a/src/groovy/org/transmartproject/db/dataquery/highdim/vcf/VcfCohortStatistics.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/vcf/VcfCohortStatistics.groovy
@@ -47,10 +47,10 @@ class VcfCohortStatistics implements VcfCohortInfo {
     List<Double> getAlleleFrequency() {
         alleleCount.collect {  it / totalAlleleCount }
     }
-    
+
     @Override
     String getReferenceAllele() {
-        majorAllele
+        dataRow.referenceAllele
     }
 
     @Override
@@ -68,10 +68,11 @@ class VcfCohortStatistics implements VcfCohortInfo {
             return
 
         // Store generic allele distribution
+        //TODO the order of keys and values is predictable and corresponds implicitly in this case (LinkedHashMap).
         alleles = new ArrayList<String>(numAlleles.keySet())
         alleleCount = new ArrayList<Integer>(numAlleles.values())
         totalAlleleCount = alleleCount.sum()
-        
+
         // Find the most frequent and second most frequent alleles
         majorAllele = numAlleles.max { it.value }?.key
         minorAllele = numAlleles.findAll { it.key != majorAllele }.max { it.value }?.key ?: "."

--- a/transmart-core-db-tests/test/unit/org/transmartproject/db/dataquery/highdim/vcf/VcfCohortStatisticsTests.groovy
+++ b/transmart-core-db-tests/test/unit/org/transmartproject/db/dataquery/highdim/vcf/VcfCohortStatisticsTests.groovy
@@ -63,6 +63,8 @@ class VcfCohortStatisticsTests {
         assertThat cohortStatistics.majorAllele, equalTo(".")
         assertThat cohortStatistics.minorAllele, equalTo(".")
         assertThat cohortStatistics.minorAlleleFrequency, closeTo(0.0 as Double, 0.001 as Double)
+        assertThat cohortStatistics.referenceAllele, equalTo("G")
+        assertThat cohortStatistics.alternativeAlleles, empty()
     }
 
     @Test
@@ -109,6 +111,9 @@ class VcfCohortStatisticsTests {
         assertThat cohortStatistics.genomicVariantTypes, hasSize(3)
         assertThat cohortStatistics.genomicVariantTypes, hasItem( equalTo( GenomicVariantType.INS ) )
         assertThat cohortStatistics.genomicVariantTypes, hasItem( equalTo( GenomicVariantType.SNP ) )
+
+        assertThat cohortStatistics.referenceAllele, equalTo("G")
+        assertThat cohortStatistics.alternativeAlleles, containsInAnyOrder("A", "TG")
     }
 
     @Test
@@ -150,6 +155,9 @@ class VcfCohortStatisticsTests {
         assertThat cohortStatistics.genomicVariantTypes, hasSize(4)
         assertThat cohortStatistics.genomicVariantTypes, hasItem( equalTo( GenomicVariantType.DEL ) )
         assertThat cohortStatistics.genomicVariantTypes, hasItem( equalTo( GenomicVariantType.DIV ) )
+
+        assertThat cohortStatistics.referenceAllele, equalTo("G")
+        assertThat cohortStatistics.alternativeAlleles, containsInAnyOrder("AT", "T", "CG")
     }
 
     @Test
@@ -193,6 +201,9 @@ class VcfCohortStatisticsTests {
         assertThat cohortStatistics.alleleCount[ cohortStatistics.alleles.indexOf( "G" ) ], equalTo(2)
         assertThat cohortStatistics.alleleCount[ cohortStatistics.alleles.indexOf( "AT" ) ], equalTo(4)
         assertThat cohortStatistics.alleleCount[ cohortStatistics.alleles.indexOf( "T" ) ], equalTo(1)
+
+        assertThat cohortStatistics.referenceAllele, equalTo("G")
+        assertThat cohortStatistics.alternativeAlleles, containsInAnyOrder("AT", "T")
     }
     
 }


### PR DESCRIPTION
- Reference nucleotide is not necessarily most frequent one
  among a population that represented in the file.