### PR TITLE
Fix query for EXCLUDE result set criteria for Oracle

### DIFF
--- a/grails-app/services/org/transmartproject/db/querytool/PatientSetQueryBuilderService.groovy
+++ b/grails-app/services/org/transmartproject/db/querytool/PatientSetQueryBuilderService.groovy
@@ -102,7 +102,7 @@ class PatientSetQueryBuilderService {
                 "$panel.select GROUP BY patient_num"
             } else {
                 "SELECT patient_num FROM patient_dimension " +
-                        "EXCEPT ($panel.select)"
+                        "$databasePortabilityService.complementOperator ($panel.select)"
             }
         } else {
             panelClauses.inject("") { String acc, panel ->


### PR DESCRIPTION
EXCEPT operator is not defined for Oracle, MINUS should be used instead. While building patient set query it fails if you mark one of subsets as Excluded.