### PR TITLE
Fix relation from DeVariantSubjectSummary to DeVariantSubjectDetail

### DIFF
--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/vcf/DeVariantSubjectDetailCoreDb.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/vcf/DeVariantSubjectDetailCoreDb.groovy
@@ -50,7 +50,7 @@ class DeVariantSubjectDetailCoreDb implements Serializable {
         table     schema:  'deapp', name: 'de_variant_subject_detail'
         version   false
 
-        id composite: ['chr', 'pos']
+        id composite: ['dataset', 'rsId', 'chr', 'pos']
 
         dataset column: 'dataset_id'
         rsId    column: 'rs_id'

--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/vcf/DeVariantSubjectSummaryCoreDb.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/vcf/DeVariantSubjectSummaryCoreDb.groovy
@@ -32,6 +32,8 @@ class DeVariantSubjectSummaryCoreDb {
     Boolean reference
     Integer allele1
     Integer allele2
+    String chr
+    Long pos
 
     DeVariantSubjectDetailCoreDb jDetail
     DeVariantSubjectIdxCoreDb subjectIndex
@@ -52,18 +54,20 @@ class DeVariantSubjectSummaryCoreDb {
             generator: 'sequence',
             params: [sequence: 'de_variant_subject_summary_seq', schema: 'deapp']
             
-        dataset column: 'dataset_id', insertable: false, updateable: false
+        dataset column: 'dataset_id'
         assay   column: 'assay_id'
-        subjectId column: 'subject_id', insertable: false, updateable: false
+        subjectId column: 'subject_id'
 
         // this is needed due to a Criteria bug.
         // see https://forum.hibernate.org/viewtopic.php?f=1&t=1012372
         columns {
-            jDetail {
+            jDetail(insertable: false, updateable: false) {
+                column name: 'dataset_id'
+                column name: 'rs_id'
                 column name: 'chr'
                 column name: 'pos'
             }
-            subjectIndex {
+            subjectIndex(insertable: false, updateable: false) {
                 column name: 'dataset_id'
                 column name: 'subject_id'
             }

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/vcf/VcfModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/vcf/VcfModule.groovy
@@ -140,6 +140,7 @@ class VcfModule extends AbstractHighDimensionDataTypeModule {
             }
             order 'chr',  'asc'
             order 'pos',  'asc'
+            order 'rsId', 'asc'
             order 'assayId',  'asc' // important
 
             // because we're using this transformer, every column has to have an alias
@@ -162,7 +163,7 @@ class VcfModule extends AbstractHighDimensionDataTypeModule {
                 indicesList:           assays,
                 results:               results,
                 assayIdFromRow:        { it[0].assayId } ,
-                inSameGroup:           { a, b -> a[0].chr == b[0].chr && a[0].pos == b[0].pos },
+                inSameGroup:           { a, b -> a[0].chr == b[0].chr && a[0].pos == b[0].pos && a[0].rsId == b[0].rsId },
                 finalizeGroup:         { List list -> /* list of all the results belonging to a group defined by inSameGroup */
                     /* list of arrays with one element: a map */
                     /* we may have nulls if allowMissingAssays is true,

--- a/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/vcf/VcfTestData.groovy
+++ b/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/vcf/VcfTestData.groovy
@@ -126,12 +126,12 @@ class VcfTestData  {
         DeSubjectSampleMapping assay,
         DeVariantSubjectIdxCoreDb subjectIndex
             ->
-            // Dataset and subjectId are inserted through the
-            // subjectIndex object
             new DeVariantSubjectSummaryCoreDb(
+                    dataset: dataset,
                     chr: 1,
                     pos: detail.pos,
                     rsId: '.',
+                    subjectId: subjectIndex.subjectId,
                     variant: ((allele1 == 0) ? detail.ref : detail.alt) + '/' +
                             ((allele2 == 0) ? detail.ref : detail.alt),
                     variantFormat: ((allele1 == 0) ? 'R':'V') + '/' +


### PR DESCRIPTION
While define relation to *de_variant_subject_detail* table *DeVariantSubjectSummaryCoreDb* ignores *dataset_id* and if you have more than one VCF file loaded with same *chr*, *pos* you will receive all these when referring to details.