### PR TITLE
Issue/genome build

### DIFF
--- a/grails-app/domain/org/transmartproject/db/dataquery/highdim/DeGplInfo.groovy
+++ b/grails-app/domain/org/transmartproject/db/dataquery/highdim/DeGplInfo.groovy
@@ -35,7 +35,7 @@ class DeGplInfo implements Platform {
         table         schema: 'deapp'
 
         id              column: 'platform',   generator: 'assigned'
-        genomeReleaseId column: 'release_nbr'
+        genomeReleaseId column: 'genome_build'
 
         version      false
     }

--- a/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/acgh/AcghTestData.groovy
+++ b/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/acgh/AcghTestData.groovy
@@ -60,7 +60,7 @@ class AcghTestData {
                 organism: 'Homo Sapiens',
                 annotationDate: Date.parse('yyyy-MM-dd', '2013-05-03'),
                 markerType: ACGH_PLATFORM_MARKER_TYPE,
-                releaseNumber: 'hg18',
+                genomeReleaseId: 'hg18',
         )
         p.id = 'test-region-platform'
         p

--- a/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseq/RnaSeqTestData.groovy
+++ b/transmart-core-db-tests/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseq/RnaSeqTestData.groovy
@@ -42,7 +42,7 @@ class RnaSeqTestData {
                 organism: 'Homo Sapiens',
                 annotationDate: Date.parse('yyyy-MM-dd', '2013-05-03'),
                 markerType: REGION_PLATFORM_MARKER_TYPE,
-                releaseNumber: 'hg18',
+                genomeReleaseId: 'hg18',
         )
         p.id = 'test-region-platform_rnaseq'
         p


### PR DESCRIPTION
@forus 
The modifications in this pull request address the issue (https://jira.ctmmtrait.nl/browse/FT-1292) of the de_gpl_info table containing two columns which are associated with a genome build/release number and therefore the confusion about which field to map to the genomeReleaseId property in the core-api. Also the confusion which database field should be filled during the upload of molecular data is addressed. With the proposed modification the genome_build field in the de_gpl_info table will be mapped to the genomeReleaseId property in the core-api. The molecular data upload pipelines which support that genome build number are registered, are modified such that this information is stored in the right field (genome_build) in de_gpl_info. The release_nbr field is with these modifications not used for storing a genome build number anymore.