### PR TITLE
Add to_char to DatabasePortabilityService

### DIFF
--- a/grails-app/services/org/transmartproject/db/support/DatabasePortabilityService.groovy
+++ b/grails-app/services/org/transmartproject/db/support/DatabasePortabilityService.groovy
@@ -145,6 +145,13 @@ class DatabasePortabilityService {
         )
     }
 
+    String toChar(String expr){
+        runCorrectImplementation(
+                {"CAST($expr as character varying)"},
+                {"to_char($expr)"}
+        )
+    }
+
     /**
      * Convert pagination limits for use with queries transformed with the
      * methods available in this class.


### PR DESCRIPTION
In some places of transmartApp code SQL function `to_char` used (i.e. 
transmartApp\grails-app\services\com\recomdata\transmart\data\export\GeneExpressionDataService.groovy#createMRNAHeatmapPathwayQuery).
It doesn't work for PostgreSQL (it has function with same name, but it requires two arguments). So it may be good to have such function in DatabasePortabilityService for such situations.