### PR TITLE
Compilestatic

### DIFF
--- a/src/groovy/org/transmartproject/db/dataquery/InMemoryTabularResult.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/InMemoryTabularResult.groovy
@@ -19,10 +19,12 @@
 
 package org.transmartproject.db.dataquery
 
+import groovy.transform.CompileStatic
 import org.transmartproject.core.dataquery.DataColumn
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.TabularResult
 
+@CompileStatic
 class InMemoryTabularResult<I extends DataColumn, R extends DataRow> implements TabularResult<I,R> {
 
     @Delegate

--- a/src/groovy/org/transmartproject/db/dataquery/MultiTabularResult.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/MultiTabularResult.groovy
@@ -18,13 +18,14 @@
  */
 package org.transmartproject.db.dataquery
 
+import groovy.transform.CompileStatic
 import org.transmartproject.core.dataquery.DataRow
 
 /**
  * Created by j.hudecek on 18-1-2015.
  */
 /**
- * Extension of {@link org.transmartproject.core.dataquery.CollectingTabularResult}.
+ * Extension of {@link org.transmartproject.db.dataquery.CollectingTabularResult}.
  * Relaxes the invariant that hold for <code>list</code> variable passed to
  * <code>finalizeGroup</code> closure - the list can no longer be assumed to be
  * of the same length for each result and it can contain multiple entries with
@@ -34,6 +35,7 @@ import org.transmartproject.core.dataquery.DataRow
  * @param < C > the type for the columns
  * @param < R > the type for the rows
  */
+@CompileStatic
 class MultiTabularResult<C, R extends DataRow> extends CollectingTabularResult {
     final String columnEntityName = 'assay'
     protected void finalizeCollectedEntries(ArrayList collectedEntries) {

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/DefaultHighDimensionTabularResult.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/DefaultHighDimensionTabularResult.groovy
@@ -19,11 +19,13 @@
 
 package org.transmartproject.db.dataquery.highdim
 
+import groovy.transform.CompileStatic
 import groovy.transform.ToString
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.db.dataquery.CollectingTabularResult
 
+@CompileStatic
 @ToString
 class DefaultHighDimensionTabularResult<R extends DataRow>
         extends CollectingTabularResult<AssayColumn, R> {

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionDataTypeResourceImpl.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/HighDimensionDataTypeResourceImpl.groovy
@@ -23,6 +23,7 @@ import grails.orm.HibernateCriteriaBuilder
 import groovy.transform.EqualsAndHashCode
 import groovy.util.logging.Log4j
 import org.hibernate.ScrollMode
+import org.hibernate.StatelessSession
 import org.hibernate.engine.SessionImplementor
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
@@ -53,6 +54,7 @@ class HighDimensionDataTypeResourceImpl implements HighDimensionDataTypeResource
         this.module = module
     }
 
+    // Lazy otherwise EqualsAndHashCode does not pick it up
     @Lazy
     String dataTypeName = module.name
 
@@ -61,7 +63,7 @@ class HighDimensionDataTypeResourceImpl implements HighDimensionDataTypeResource
         module.description
     }
 
-    protected SessionImplementor openSession() {
+    protected StatelessSession openSession() {
         module.sessionFactory.openStatelessSession()
     }
 

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/RepeatedEntriesCollectingTabularResult.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/RepeatedEntriesCollectingTabularResult.groovy
@@ -22,9 +22,11 @@ package org.transmartproject.db.dataquery.highdim
 import com.google.common.collect.AbstractIterator
 import com.google.common.collect.Iterators
 import com.google.common.collect.PeekingIterator
+import groovy.transform.CompileStatic
 import org.transmartproject.core.dataquery.DataColumn
 import org.transmartproject.core.dataquery.TabularResult
 
+@CompileStatic
 class RepeatedEntriesCollectingTabularResult<T extends AbstractDataRow> {
 
     @Delegate
@@ -32,7 +34,7 @@ class RepeatedEntriesCollectingTabularResult<T extends AbstractDataRow> {
 
     Closure<Object> collectBy = Closure.IDENTITY
 
-    Closure<T> resultItem = { it[0] }
+    Closure<T> resultItem = { List<T> it -> (T) it[0] }
 
     Iterator<T> getRows() {
         new RepeatedEntriesCollectingIterator(tabularResult.iterator())
@@ -42,12 +44,13 @@ class RepeatedEntriesCollectingTabularResult<T extends AbstractDataRow> {
         getRows()
     }
 
+    @CompileStatic
     public class RepeatedEntriesCollectingIterator extends AbstractIterator<T> {
 
         PeekingIterator<T> sourceIterator
 
         RepeatedEntriesCollectingIterator(Iterator<T> sourceIterator) {
-            this.sourceIterator = Iterators.peekingIterator sourceIterator
+            this.sourceIterator = (PeekingIterator<T>) Iterators.peekingIterator((Iterator) sourceIterator)
         }
 
         @Override
@@ -58,14 +61,14 @@ class RepeatedEntriesCollectingTabularResult<T extends AbstractDataRow> {
                 return
             }
 
-            collected << sourceIterator.next()
+            collected.add((T) sourceIterator.next())
             while (sourceIterator.hasNext() &&
-                    collectBy(sourceIterator.peek()) != null &&
-                    collectBy(sourceIterator.peek()) == collectBy(collected[0])) {
-                collected << sourceIterator.next()
+                    collectBy.call(sourceIterator.peek()) != null &&
+                    collectBy.call(sourceIterator.peek()) == collectBy.call(collected[0])) {
+                collected.add((T) sourceIterator.next())
             }
 
-            resultItem(collected)
+            (T) resultItem.call(collected)
         }
     }
 }

--- a/src/groovy/org/transmartproject/db/util/ScrollableResultsIterator.groovy
+++ b/src/groovy/org/transmartproject/db/util/ScrollableResultsIterator.groovy
@@ -1,8 +1,10 @@
 package org.transmartproject.db.util
 
+import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j
 import org.hibernate.ScrollableResults
 
+@CompileStatic
 @Log4j
 class ScrollableResultsIterator<T> implements Iterator<T>, Closeable {
 
@@ -27,7 +29,7 @@ class ScrollableResultsIterator<T> implements Iterator<T>, Closeable {
     T next() {
         if (hasNext()) {
             hasNext = null
-            scrollableResults.get(0)
+            (T) scrollableResults.get(0)
         } else {
             throw new NoSuchElementException()
         }

--- a/src/groovy/org/transmartproject/db/util/ScrollableResultsWrappingIterable.groovy
+++ b/src/groovy/org/transmartproject/db/util/ScrollableResultsWrappingIterable.groovy
@@ -1,8 +1,10 @@
 package org.transmartproject.db.util
 
+import groovy.transform.CompileStatic
 import org.hibernate.ScrollableResults
 import org.transmartproject.core.IterableResult
 
+@CompileStatic
 class ScrollableResultsWrappingIterable<T> extends AbstractOneTimeCallIterable<T> implements IterableResult<T> {
 
     protected final ScrollableResultsIterator scrollableResultsIterator

--- a/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/mirna/MirnaSharedEndToEndRetrievalTests.groovy
+++ b/transmart-core-db-tests/test/integration/org/transmartproject/db/dataquery/highdim/mirna/MirnaSharedEndToEndRetrievalTests.groovy
@@ -191,7 +191,7 @@ abstract class MirnaSharedEndToEndRetrievalTests {
         testWithMissingDataAssay(-50000L)
         result.allowMissingAssays = false
         shouldFail UnexpectedResultException, {
-            result.rows
+            result.rows.next()
         }
     }
 


### PR DESCRIPTION
New attempt for https://github.com/transmart/transmart-core-db/pull/44

@CompileStatic the inner iterators that return data from core-db.

I have not done benchmarks at this moment, this is just on the general principle that it makes sense to CompileStatic the inner loops that retrieve megabytes or gigabytes of data.