### PR TITLE
Add maxResults to search autocomplete queries. Add probe id support to microarray data type.

### DIFF
--- a/src/groovy/org/transmartproject/db/dataquery/highdim/metabolite/MetaboliteModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/metabolite/MetaboliteModule.groovy
@@ -174,6 +174,7 @@ class MetaboliteModule extends AbstractHighDimensionDataTypeModule {
             ilike(search_property, search_term + '%')
             projections { distinct(search_property) }
             order(search_property, 'ASC')
+            maxResults(100)
         }
     }
 

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/mirna/AbstractMirnaSharedModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/mirna/AbstractMirnaSharedModule.groovy
@@ -18,18 +18,14 @@
  */
 
 package org.transmartproject.db.dataquery.highdim.mirna
-
 import grails.orm.HibernateCriteriaBuilder
-import org.hibernate.Criteria
 import org.hibernate.ScrollableResults
-import org.hibernate.criterion.Restrictions
 import org.hibernate.engine.SessionImplementor
 import org.hibernate.transform.Transformers
 import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.projections.Projection
-import org.transmartproject.core.querytool.ConstraintByOmicsValue
 import org.transmartproject.core.querytool.HighDimensionFilterType
 import org.transmartproject.db.dataquery.highdim.AbstractHighDimensionDataTypeModule
 import org.transmartproject.db.dataquery.highdim.DeSubjectSampleMapping
@@ -43,7 +39,6 @@ import javax.annotation.PostConstruct
 
 import static org.hibernate.sql.JoinFragment.INNER_JOIN
 import static org.transmartproject.db.util.GormWorkarounds.createCriteriaBuilder
-
 /*
  * Mirna QPCR and Mirna SEQ are different data types (according to the user), but they have basically the same
  * implementation. We solve that by having a shared implementation in AbstractMirnaSharedModule.
@@ -164,6 +159,7 @@ abstract class AbstractMirnaSharedModule extends AbstractHighDimensionDataTypeMo
             ilike(search_property, search_term + '%')
             projections { distinct(search_property) }
             order(search_property, 'ASC')
+            maxResults(100)
         }
     }
 

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/mrna/MrnaModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/mrna/MrnaModule.groovy
@@ -187,7 +187,7 @@ class MrnaModule extends AbstractHighDimensionDataTypeModule {
 
     @Override
     List<String> getSearchableAnnotationProperties() {
-        ['geneSymbol']
+        ['geneSymbol', 'probeId']
     }
 
     @Override

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/protein/ProteinModule.groovy
@@ -18,18 +18,14 @@
  */
 
 package org.transmartproject.db.dataquery.highdim.protein
-
 import grails.orm.HibernateCriteriaBuilder
-import org.hibernate.Criteria
 import org.hibernate.ScrollableResults
-import org.hibernate.criterion.Restrictions
 import org.hibernate.engine.SessionImplementor
 import org.hibernate.transform.Transformers
 import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.projections.Projection
-import org.transmartproject.core.querytool.ConstraintByOmicsValue
 import org.transmartproject.core.querytool.HighDimensionFilterType
 import org.transmartproject.db.dataquery.highdim.AbstractHighDimensionDataTypeModule
 import org.transmartproject.db.dataquery.highdim.DeSubjectSampleMapping
@@ -180,6 +176,7 @@ class ProteinModule extends AbstractHighDimensionDataTypeModule {
             ilike(search_property, search_term + '%')
             projections { distinct(search_property) }
             order(search_property, 'ASC')
+            maxResults(100)
         }
     }
 

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rbm/RbmModule.groovy
@@ -174,6 +174,7 @@ class RbmModule extends AbstractHighDimensionDataTypeModule {
                 distinct(search_property)
             }
             order(search_property, 'ASC')
+            maxResults(100)
         }
     }
 

--- a/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogModule.groovy
+++ b/src/groovy/org/transmartproject/db/dataquery/highdim/rnaseqcog/RnaSeqCogModule.groovy
@@ -18,18 +18,14 @@
  */
 
 package org.transmartproject.db.dataquery.highdim.rnaseqcog
-
 import grails.orm.HibernateCriteriaBuilder
-import org.hibernate.Criteria
 import org.hibernate.ScrollableResults
-import org.hibernate.criterion.Restrictions
 import org.hibernate.engine.SessionImplementor
 import org.hibernate.transform.Transformers
 import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.projections.Projection
-import org.transmartproject.core.querytool.ConstraintByOmicsValue
 import org.transmartproject.core.querytool.HighDimensionFilterType
 import org.transmartproject.db.dataquery.highdim.AbstractHighDimensionDataTypeModule
 import org.transmartproject.db.dataquery.highdim.DeSubjectSampleMapping
@@ -41,7 +37,6 @@ import org.transmartproject.db.dataquery.highdim.parameterproducers.*
 
 import static org.hibernate.sql.JoinFragment.INNER_JOIN
 import static org.transmartproject.db.util.GormWorkarounds.createCriteriaBuilder
-
 /**
  * Module for RNA-seq, as implemented for Oracle by Cognizant.
  * This name is to distinguish it from the TraIT implementation.
@@ -170,12 +165,13 @@ class RnaSeqCogModule extends AbstractHighDimensionDataTypeModule {
             ilike(search_property, search_term + '%')
             projections { distinct(search_property) }
             order(search_property, 'ASC')
+            maxResults(100)
         }
     }
 
     @Override
     List<String> getSearchableAnnotationProperties() {
-        ['geneSymbol']
+        ['geneSymbol','transcriptId']
     }
 
     @Override


### PR DESCRIPTION
Search autocomplete for some datatypes did not yet limit the amount of results, resulting in poor user experience due to long loading times.